### PR TITLE
types: added types for Button, Form and Input element

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -14,13 +14,26 @@ const Button = ({
   disabled,
   loading,
   onClick = () => {},
+  ...remainingProps
 }: ButtonPropTypes): JSX.Element => {
   const ButtonWrapper = ({
     children,
   }: {
     children: JSX.Element;
   }): JSX.Element =>
-    href && !loading && !disabled ? <a href={href}>{children}</a> : children;
+    href && !loading && !disabled ? (
+      <a
+        href={href}
+        {...(remainingProps as React.DetailedHTMLProps<
+          React.AnchorHTMLAttributes<HTMLAnchorElement>,
+          HTMLAnchorElement
+        >)}
+      >
+        {children}
+      </a>
+    ) : (
+      children
+    );
 
   const generateClassName = (): string => {
     let name = `${className} void-btn `;
@@ -38,6 +51,11 @@ const Button = ({
         className={`${generateClassName()}`}
         onClick={disabled || loading ? () => {} : onClick}
         type={disabled ? "button" : type}
+        {...(!href &&
+          (remainingProps as React.DetailedHTMLProps<
+            React.ButtonHTMLAttributes<HTMLButtonElement>,
+            HTMLButtonElement
+          >))}
       >
         {loading && (
           <>

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -1,4 +1,12 @@
-export type ButtonPropTypes = {
+export type ButtonPropTypes<href = string | undefined> = (href extends undefined
+  ? React.DetailedHTMLProps<
+      React.ButtonHTMLAttributes<HTMLButtonElement>,
+      HTMLButtonElement
+    >
+  : React.DetailedHTMLProps<
+      React.AnchorHTMLAttributes<HTMLAnchorElement>,
+      HTMLAnchorElement
+    >) & {
   disabled?: boolean;
   loading?: boolean;
   className?: string;

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -6,6 +6,7 @@ const Form = ({
   children,
   onSubmit,
   style,
+  ...defaultFormProps
 }: FormPropTypes): JSX.Element => {
   const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -24,10 +25,10 @@ const Form = ({
 
   return (
     <form
-      action=""
       className={className}
       onSubmit={handleOnSubmit}
       style={style}
+      {...defaultFormProps}
     >
       {children}
     </form>

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -1,6 +1,9 @@
 import React from "react";
 
-export type FormPropTypes = {
+export type FormPropTypes = React.DetailedHTMLProps<
+  React.FormHTMLAttributes<HTMLFormElement>,
+  HTMLFormElement
+> & {
   className?: string;
   onSubmit?: (values: object) => void;
   children?: JSX.Element;

--- a/src/components/Input/types.ts
+++ b/src/components/Input/types.ts
@@ -3,7 +3,10 @@ import DateInput from "./date";
 import SelectInput from "./select";
 import TextInput from "./text";
 
-export type InputPropTypes = {
+export type InputPropTypes = React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> & {
   disabled?: boolean;
   loading?: boolean;
   placeholder?: string;
@@ -43,12 +46,8 @@ export const defaultProps = (props: InputPropTypes, className?: string) => {
       className || ""
     } ${props.className || ""}`,
     id: props.name,
-    name: props.name,
-    value: props.value,
-    disabled: props.disabled,
-    placeholder: props.placeholder,
-    style: props.style,
     onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
       props.onChange ? props.onChange(e.target.value) : () => {},
+    ...props, // Default props
   };
 };

--- a/src/components/Input/types.ts
+++ b/src/components/Input/types.ts
@@ -42,12 +42,12 @@ export type InputTypeTypes = {
 
 export const defaultProps = (props: InputPropTypes, className?: string) => {
   return {
+    ...props, // Default props
     className: `void-input ${props.loading ? "void-input-loading" : ""} ${
       className || ""
     } ${props.className || ""}`,
     id: props.name,
     onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
       props.onChange ? props.onChange(e.target.value) : () => {},
-    ...props, // Default props
   };
 };


### PR DESCRIPTION
Currently, the elements do not accept any default parameters of the base element and only accept the custom parameters.

This PR aims to add types for the following elements
- Button
- Form
- Input element

Before merging this PR, please check the file `src/components/Input/types.ts` I removed the lines from `46-50` as the code would handle these at line number `51`. If this needs to be reverted do mention me.

cc: @Nandan-unni 